### PR TITLE
Add multiline message support

### DIFF
--- a/exe/slackit
+++ b/exe/slackit
@@ -63,7 +63,7 @@ def process_arguments
 
     begin
         optparse.parse!
-        options[:message] = gets.downcase if !STDIN.tty? # override message parameter if data is piped in
+        options[:message] = ARGF.read if !STDIN.tty? # override message parameter if data is piped in
         missing = mandatory.select { |param| options[param].nil? }
         raise OptionParser::MissingArgument.new(missing.join(', ')) unless missing.empty?
     rescue OptionParser::InvalidOption, OptionParser::MissingArgument => e

--- a/lib/slackit.rb
+++ b/lib/slackit.rb
@@ -21,6 +21,7 @@ class Slackit
         headers = { 'Content-Type' => 'application/json' }
 
         # payload
+        text = text.gsub('\\n', "\n") # ensure newlines are not escaped
         body = { 'text' => text, 'icon_emoji' => @icon_emoji, 'username' => @username }
 
         # add the channel if there is one otherwise the default channel


### PR DESCRIPTION
This PR adds support for sending a message using newline characters. Currently, these are escaped by Ruby, resulting in a single line message. Additionally, I have updated the pipe functionality to also support passing in multiline files. Cheers!